### PR TITLE
Fix setting expiration dates on CA and client certs

### DIFF
--- a/certs/cfg/braidcert.CA.cfg
+++ b/certs/cfg/braidcert.CA.cfg
@@ -1,7 +1,6 @@
 # self-signed root CA certificate
 [ req ]
 prompt                 = no
-days                   = 3650
 string_mask            = utf8only
 default_md             = sha256
 distinguished_name     = req_distinguished_name

--- a/src/braidcert_api.erl
+++ b/src/braidcert_api.erl
@@ -106,7 +106,7 @@ generate_ca() ->
         "-new",
         "-x509",
         "-config", ca_cfg_file(),
-        "-days", "3650",
+        "-days", "30000",
         "-key", ca_keyfile(),
         "-out", ca_file()
     ],
@@ -124,7 +124,7 @@ generate_cert(CertDir, CsrFile) ->
         "-CAcreateserial",
         "-extfile", ext_file(),
         "-copy_extensions", "copy",
-        "-days", "3650",
+        "-days", "30000",
         "-out", CertFile
     ],
     {ok, _} = run_cmd(Cmd, Args),

--- a/src/braidcert_api.erl
+++ b/src/braidcert_api.erl
@@ -106,6 +106,7 @@ generate_ca() ->
         "-new",
         "-x509",
         "-config", ca_cfg_file(),
+        "-days", "3650",
         "-key", ca_keyfile(),
         "-out", ca_file()
     ],
@@ -123,6 +124,7 @@ generate_cert(CertDir, CsrFile) ->
         "-CAcreateserial",
         "-extfile", ext_file(),
         "-copy_extensions", "copy",
+        "-days", "3650",
         "-out", CertFile
     ],
     {ok, _} = run_cmd(Cmd, Args),


### PR DESCRIPTION
The "days" field is never valid in an OpenSSL config file. We have to pass the expiration as an argument to the CLI.
This fix makes sure we set a long expirity as we intended (30000 days == 82 years), instead of the default 30.